### PR TITLE
fix(compose): correct Mongo 4.4 healthcheck try/catch order

### DIFF
--- a/compose.external.yml
+++ b/compose.external.yml
@@ -103,8 +103,7 @@ services:
   #       - CMD-SHELL
   #       - >
   #         test $$(mongo --quiet --host 127.0.0.1:27017 --eval
-  #         "try { rs.initiate({_id:'rs0', members:[{_id:0, host:'mongo:27017'}]}).ok }
-  #         catch (e) { rs.status().ok }") -eq 1
+  #         "try { rs.status().ok } catch (e) { rs.initiate({_id:'rs0', members:[{_id:0, host:'mongo:27017'}]}).ok }") -eq 1
   #     interval: 5s
   #     timeout: 5s
   #     retries: 12

--- a/compose.external.yml
+++ b/compose.external.yml
@@ -101,9 +101,9 @@ services:
   #   healthcheck:
   #     test:
   #       - CMD-SHELL
-  #       - >
-  #         test $$(mongo --quiet --host 127.0.0.1:27017 --eval
-  #         "try { rs.status().ok } catch (e) { rs.initiate({_id:'rs0', members:[{_id:0, host:'mongo:27017'}]}).ok }") -eq 1
+  #       - |
+  #         RESULT=$$(mongo --quiet --host 127.0.0.1:27017 --eval 'try { if (rs.status().ok === 1) 1; else { rs.initiate({_id:"rs0", members:[{_id:0, host:"mongo:27017"}]}); rs.status().ok; } } catch (e) { rs.initiate({_id:"rs0", members:[{_id:0, host:"mongo:27017"}]}); rs.status().ok; }')
+  #         test "$$RESULT" = "1"
   #     interval: 5s
   #     timeout: 5s
   #     retries: 12


### PR DESCRIPTION
## Summary
Fixes the Mongo 4.4 healthcheck in `compose.external.yml` so it passes when the replica set is already initialized (e.g. when reusing existing data in `./data/mongo`). This issue only affected Mongo 4.4; the Mongo 8.0 healthcheck did not show the same behaviour.

## Problem
With the previous order (`rs.initiate()` first, `rs.status().ok` in the catch), the healthcheck failed on machines where Mongo 4.4 had been run before. With existing data, the replica set is already initialized; in 4.4, `rs.initiate()` then returns a value that evaluates to 0, so the healthcheck kept the container unhealthy.

## Solution
Use try `rs.status().ok` first and call `rs.initiate()` only in the catch. This works for both a fresh start and when reusing persistent data.

## Testing
- Verified on a machine with existing Mongo 4.4 data: healthcheck now passes and the mongo service becomes healthy.


## Type of change
- [ ] Bug fix
- [ ] New feature
- [x] Docs update
- [ ] Build/CI

## How was this tested?
Commands, test output, or manual steps.

## Checklist
- [x] I read `CONTRIBUTING.md`.
- [ ] I updated README/docs if behavior or flags/env changed
