### PR TITLE
Load RedisBloom module conditionally

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -225,7 +225,13 @@ func startAllInOneInfra(ctx context.Context) (*infraSuite, error) {
 		"--maxmemory-policy", "noeviction",
 		"--protected-mode", "no",
 		"--bind", "127.0.0.1",
-		"--loadmodule", "/opt/redis-stack/lib/redisbloom.so",
+	}
+
+	// Load RedisBloom only if the .so is present; path can vary across image versions
+	const redisBloomSO = "/opt/redis-stack/lib/redisbloom.so"
+	if _, err := os.Stat(redisBloomSO); err == nil {
+		redisArgs = append(redisArgs, "--loadmodule", redisBloomSO)
+		log.Info("RedisBloom module found, loading explicitly", zap.String("path", redisBloomSO))
 	}
 
 	log.Info("starting embedded Redis",


### PR DESCRIPTION
## Summary
Fixed Redis startup failing when the RedisBloom module isn't available. Docker image versions vary on whether they include this or where it's located. Added a check to only load the module if the file exists. Fixes #65.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Build/CI

## How was this tested?
Tested locally with and without the RedisBloom .so file present. Verified the module loads when available and Redis starts cleanly when it's not.

## Checklist
- [x] I read `CONTRIBUTING.md`.
- [ ] I updated README/docs if behavior or flags/env changed